### PR TITLE
Fix link for relevent svelte issue in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ warning in future versions of Svelte. This library should be considered merely
 as a stop-gap solution for those using Svelte in production today.
 
 Relevant Svelte issues: [svelte#1096](https://github.com/sveltejs/svelte/issues/1096)
-[svelte#3587](https://github.com/sveltejs/svelte/issues/#3587)
-[svelte#3733](https://github.com/sveltejs/svelte/issues/#3733)
+[svelte#3587](https://github.com/sveltejs/svelte/issues/3587)
+[svelte#3733](https://github.com/sveltejs/svelte/issues/3733)
 
 **[REPL Demo](https://svelte.dev/repl/9d44bbcf30444cd08cca6b85f07f2e2a?version=3.29.4)**
 


### PR DESCRIPTION
Hello,

Thanks for the work, this workaround works great until Svelte support it natively

Just a small PR to fix the links in the readme that were working properly because of a typo.