### PR TITLE
Fix incorrect main script path in package.json and set package to type: module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@crown/error-boundary",
   "svelte": "src/index.js",
-  "module": "index/index.js",
-  "main": "index/index.js",
+  "type": "module",
+  "main": "src/index.js",
   "license": "MIT",
   "scripts": {},
   "devDependencies": {


### PR DESCRIPTION
The path to `module` and `main` is not correct. Without this change you get the following Rollup error when building (note the import is in a `.ts` file, not `.svelte`)

```
(!) Plugin typescript: @rollup/plugin-typescript TS2307: Cannot find module '@crownframework/svelte-error-boundary' or its corresponding type declarations.
src/lib/error.ts: (1:32)
```